### PR TITLE
Add minimal Next.js future tree explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# precog
+# Precog Future Explorer
+
+This project contains a minimal Next.js application that visualizes a tree of hypothetical futures. Each node includes a probability and you can navigate down the tree using number key hotkeys.
+
+## Development
+
+1. Install dependencies (requires internet access):
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+3. Build for production:
+   ```bash
+   npm run build
+   ```
+
+The initial data lives in `src/data/fakeTree.ts`. You can modify or extend it to model additional futures.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/pages/building-your-application/typescript#type-checking

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: false
+  }
+}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "precog",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5",
+    "@types/react": "18.2.8",
+    "@types/node": "20.12.6"
+  }
+}

--- a/src/components/TreeExplorer.tsx
+++ b/src/components/TreeExplorer.tsx
@@ -1,0 +1,60 @@
+'use client';
+import { useEffect, useState, useCallback } from 'react';
+import { TreeNode } from '../data/fakeTree';
+
+interface Props {
+  tree: TreeNode;
+}
+
+export default function TreeExplorer({ tree }: Props) {
+  const [path, setPath] = useState<TreeNode[]>([tree]);
+
+  const current = path[path.length - 1];
+  const children = current.children || [];
+
+  const handleKey = useCallback(
+    (e: KeyboardEvent) => {
+      const index = parseInt(e.key, 10) - 1;
+      if (!isNaN(index) && children[index]) {
+        setPath([...path, children[index]]);
+      }
+    },
+    [children, path]
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKey);
+    return () => {
+      window.removeEventListener('keydown', handleKey);
+    };
+  }, [handleKey]);
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Future Tree Explorer</h1>
+      <div className="mb-4">
+        {path.map((node, idx) => (
+          <span key={node.id}>
+            {idx > 0 && ' -> '} {node.text}
+          </span>
+        ))}
+      </div>
+      <div className="space-y-2">
+        {children.length === 0 && <p>No further branches.</p>}
+        {children.map((child, idx) => (
+          <div key={child.id} className="border p-2 rounded">
+            <div className="font-semibold">
+              {idx + 1}. {child.text}
+            </div>
+            <div className="text-sm text-gray-600">Probability: {child.probability}</div>
+          </div>
+        ))}
+      </div>
+      {children.length > 0 && (
+        <p className="mt-4 text-sm text-gray-500">
+          Press the number key corresponding to a branch to follow it.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/data/fakeTree.ts
+++ b/src/data/fakeTree.ts
@@ -1,0 +1,72 @@
+export interface TreeNode {
+  id: string;
+  text: string;
+  probability: number;
+  children?: TreeNode[];
+}
+
+export const fakeTree: TreeNode = {
+  id: 'root',
+  text: 'GPT-5 launches next year',
+  probability: 1,
+  children: [
+    {
+      id: 'industry',
+      text: 'Industry accelerates AI adoption',
+      probability: 0.7,
+      children: [
+        {
+          id: 'regulation',
+          text: 'Governments impose new regulations',
+          probability: 0.5,
+          children: [
+            {
+              id: 'compliance',
+              text: 'Companies invest heavily in compliance',
+              probability: 0.6,
+            },
+            {
+              id: 'loopholes',
+              text: 'Companies seek loopholes',
+              probability: 0.4,
+            }
+          ]
+        },
+        {
+          id: 'noRegulation',
+          text: 'Minimal regulation is enacted',
+          probability: 0.5,
+          children: [
+            {
+              id: 'boom',
+              text: 'Rapid market expansion',
+              probability: 0.8,
+            },
+            {
+              id: 'backlash',
+              text: 'Public backlash against AI',
+              probability: 0.2,
+            }
+          ]
+        }
+      ]
+    },
+    {
+      id: 'slowAdoption',
+      text: 'Adoption remains slow',
+      probability: 0.3,
+      children: [
+        {
+          id: 'researchFocus',
+          text: 'Research continues but commercialization lags',
+          probability: 0.6,
+        },
+        {
+          id: 'stagnation',
+          text: 'Overall stagnation in AI progress',
+          probability: 0.4,
+        }
+      ]
+    }
+  ]
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,10 @@
+import TreeExplorer from '../components/TreeExplorer';
+import { fakeTree } from '../data/fakeTree';
+
+export default function Home() {
+  return (
+    <main className="p-8">
+      <TreeExplorer tree={fakeTree} />
+    </main>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add Next.js configuration with TypeScript
- implement a simple `TreeExplorer` component
- provide fake future tree data
- show tree on the home page
- document how to build and run the project

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1acd6020832a875fec15038a32a7